### PR TITLE
Update images

### DIFF
--- a/img/atbash.svg
+++ b/img/atbash.svg
@@ -1,26 +1,6 @@
-<svg width="1000" height="1000" viewBox="0 0 1000 1000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<title>ATBASH</title>
-<desc>Created using Figma</desc>
-<g id="Canvas" transform="translate(-4143 -124)">
-<clipPath id="clip-0" clip-rule="evenodd">
-<path d="M 4143 124L 5143 124L 5143 1124L 4143 1124L 4143 124Z" fill="#FFFFFF"/>
-</clipPath>
-<g id="ATBASH" clip-path="url(#clip-0)">
-<path d="M 4143 124L 5143 124L 5143 1124L 4143 1124L 4143 124Z" fill="#FFFFFF"/>
-<g id="Line">
-<use xlink:href="#path0_stroke" transform="matrix(-1.05818e-16 1 -1 -1.05818e-16 4618 349)"/>
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="atbash">
+<rect width="16" height="16" transform="scale(4)" fill="white"/>
+<path id="Ellipse" d="M56 27V29.5L57.8035 25.2687L56 27ZM8 37V34.5L6.19653 38.7313L8 37ZM8 29.5H56V24.5H8V29.5ZM8 39.5H56V34.5H8V39.5ZM57.8035 25.2687L43.4035 10.2687L39.7965 13.7313L54.1965 28.7313L57.8035 25.2687ZM6.19653 38.7313L20.5965 53.7313L24.2035 50.2687L9.80347 35.2687L6.19653 38.7313Z" fill="black"/>
 </g>
-<g id="A">
-<use xlink:href="#path1_fill" transform="translate(4143 349)"/>
-</g>
-<g id="Z">
-<use xlink:href="#path2_fill" transform="translate(4668 349)"/>
-</g>
-</g>
-</g>
-<defs>
-<path id="path0_stroke" d="M 0 0L 550 0L 550 -50L 0 -50L 0 0Z"/>
-<path id="path1_fill" d="M 271.109 334.75L 203.469 334.75L 191.656 373L 138.922 373L 214.016 168.25L 260.422 168.25L 336.078 373L 283.062 373L 271.109 334.75ZM 215.281 296.641L 259.297 296.641L 237.219 225.625L 215.281 296.641Z"/>
-<path id="path2_fill" d="M 220.484 335.031L 318.359 335.031L 318.359 373L 158.891 373L 158.891 346.984L 256.484 206.359L 158.328 206.359L 158.328 168.25L 317.375 168.25L 317.375 193.562L 220.484 335.031Z"/>
-</defs>
 </svg>

--- a/img/vernam.svg
+++ b/img/vernam.svg
@@ -1,23 +1,6 @@
-<svg width="1000" height="1000" viewBox="0 0 1000 1000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<title>VigenereCipher</title>
-<desc>Created using Figma</desc>
-<g id="Canvas" transform="translate(-5653 -312)">
-<clipPath id="clip-0" clip-rule="evenodd">
-<path d="M 5653 312L 6653 312L 6653 1312L 5653 1312L 5653 312Z" fill="#FFFFFF"/>
-</clipPath>
-<g id="VigenereCipher" clip-path="url(#clip-0)">
-<path d="M 5653 312L 6653 312L 6653 1312L 5653 1312L 5653 312Z" fill="#FFFFFF"/>
-<g id="Plus">
-<g id="Rectangle">
-<use xlink:href="#path0_fill" transform="translate(6100.75 537)"/>
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="vernam">
+<rect width="16" height="16" transform="scale(4)" fill="white"/>
+<path id="Ellipse (Stroke)" fill-rule="evenodd" clip-rule="evenodd" d="M29.5 34.5V52H34.5V34.5H52V29.5H34.5V12H29.5V29.5H12V34.5H29.5Z" fill="black"/>
 </g>
-<g id="Rectangle">
-<use xlink:href="#path0_fill" transform="matrix(4.45326e-17 -1 1 8.41945e-17 5878 862.875)"/>
-</g>
-</g>
-</g>
-</g>
-<defs>
-<path id="path0_fill" d="M 0 51.5625C 0 23.0853 23.0853 0 51.5625 0L 51.5625 0C 80.0397 0 103.125 23.0853 103.125 51.5625L 103.125 498.438C 103.125 526.915 80.0397 550 51.5625 550L 51.5625 550C 23.0853 550 0 526.915 0 498.438L 0 51.5625Z"/>
-</defs>
 </svg>


### PR DESCRIPTION
The images used in the cipher section didn't fit the overall theme of the site very well, they've been slightly updated to fit better with the other icons (see screenshot below).

<img src="https://user-images.githubusercontent.com/19945071/47249056-f0638800-d45a-11e8-9f66-c8da29022c34.png" alt="screenshot_2018-10-20 cryptools" width=512/>